### PR TITLE
[CXCalendar] Rename CXCalendarView to CXPagedCalendar

### DIFF
--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithAccessoryViewExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithAccessoryViewExampleView.swift
@@ -26,7 +26,7 @@ struct CalendarWithAccessoryViewExampleView: View {
             }
             .build()
 
-        CXCalendarView(context: context)
+        CXPagedCalendar(context: context)
             .padding(.horizontal)
             .navigationTitle("Calendar with Accessory View")
             .navigationBarTitleDisplayMode(.inline)

--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomDayExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomDayExampleView.swift
@@ -17,7 +17,7 @@ struct CalendarWithCustomDayExampleView: View {
             }
             .build()
 
-        CXCalendarView(context: context)
+        CXPagedCalendar(context: context)
             .padding(.horizontal)
             .navigationTitle("Custom Day View")
             .navigationBarTitleDisplayMode(.inline)

--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomHeaderExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomHeaderExampleView.swift
@@ -17,7 +17,7 @@ struct CalendarWithCustomHeaderExampleView: View {
             }
             .build()
 
-        CXCalendarView(context: context)
+        CXPagedCalendar(context: context)
             .padding(.horizontal)
             .padding(.horizontal)
             .navigationTitle("Calendar with Custom Header")

--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomSelectLogicExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomSelectLogicExampleView.swift
@@ -19,7 +19,7 @@ struct CalendarWithCustomSelectLogicExampleView: View {
             }
             .build()
 
-        CXCalendarView(context: context)
+        CXPagedCalendar(context: context)
         .padding(.horizontal)
         .navigationTitle("Custom Select Logic Calendar")
         .navigationBarTitleDisplayMode(.inline)

--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithExternalMonthHeaderViewExample.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithExternalMonthHeaderViewExample.swift
@@ -23,7 +23,7 @@ struct CalendarWithExternalMonthHeaderViewExampleView: View {
             }
             .build()
 
-        CXCalendarView(context: context, backToToday: $resetToday)
+        CXPagedCalendar(context: context, backToToday: $resetToday)
             .padding(.horizontal)
             .toolbar {
                 ToolbarItem(placement: .title) {

--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithRangePickExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithRangePickExampleView.swift
@@ -28,7 +28,7 @@ struct CalendarWithRangePickExampleView: View {
             .build()
 
         VStack {
-            CXCalendarView(context: context)
+            CXPagedCalendar(context: context)
                 .navigationTitle("Calendar with Range Pick")
                 .navigationBarTitleDisplayMode(.inline)
 

--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/HorizontalCalendarExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/HorizontalCalendarExampleView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct HorizontalCalendarExampleView: View {
     var body: some View {
-        CXCalendarView()
+        CXPagedCalendar()
             .padding(.horizontal)
             .navigationTitle("Horizontal Calendar")
             .navigationBarTitleDisplayMode(.inline)

--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/VerticalCalendarExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/VerticalCalendarExampleView.swift
@@ -14,7 +14,7 @@ struct VerticalCalendarExampleView: View {
             .axis(.vertical)
             .build()
 
-        CXCalendarView(context: context)
+        CXPagedCalendar(context: context)
             .padding(.horizontal)
             .navigationTitle("Vertical Calendar")
             .navigationBarTitleDisplayMode(.inline)

--- a/Sources/CXCalendar/CXPagedCalendar.swift
+++ b/Sources/CXCalendar/CXPagedCalendar.swift
@@ -1,5 +1,5 @@
 //
-//  CXCalendarView.swift
+//  CXPagedCalendar.swift
 //  CXCalendar
 //
 //  Created by Cunqi Xiao on 7/13/25.
@@ -9,7 +9,7 @@ import CXUICore
 import CXLazyPage
 import SwiftUI
 
-public struct CXCalendarView: View, CXCalendarAccessible {
+public struct CXPagedCalendar: View, CXCalendarAccessible {
 
     // MARK: - Properties
 
@@ -26,6 +26,10 @@ public struct CXCalendarView: View, CXCalendarAccessible {
     ///   the ability to reset the calendar view to today's date externally.
     public init(context: CXCalendarContext = .paged,
                 backToToday: Binding<Bool> = .constant(false)) {
+        if context.style != .paged {
+            assertionFailure("CXPagedCalendar only supports paged style.")
+        }
+
         manager = CXCalendarManager(context: context)
         _backToToday = backToToday
     }
@@ -58,6 +62,6 @@ public struct CXCalendarView: View, CXCalendarAccessible {
 }
 
 #Preview {
-    CXCalendarView()
+    CXPagedCalendar()
 }
 


### PR DESCRIPTION
* Rename `CXCalendarView` to `CXPagedCalendar`
* Add style check to make sure correct style will be applied for the paged calendar