### PR TITLE
Remove month property from protocol

### DIFF
--- a/Sources/CXCalendar/Protocol/CXCalendarHeaderViewRepresentable.swift
+++ b/Sources/CXCalendar/Protocol/CXCalendarHeaderViewRepresentable.swift
@@ -8,5 +8,4 @@
 import SwiftUI
 
 public protocol CXCalendarHeaderViewRepresentable: View, CXCalendarAccessible {
-    var month: Date { get }
 }


### PR DESCRIPTION
Remove `month` property from `CXCalendarHeaderViewRepresentable` since not all header view require month info