### PR TITLE
[CXCalendar] Split CXCalendarContext into small pieces

### DIFF
--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomDayExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomDayExampleView.swift
@@ -47,7 +47,7 @@ struct CustomDayView: CXDayViewRepresentable {
                     .fill(backgroundColor)
             )
             .onTapGesture {
-                guard manager.context.canSelect(month, day, calendar) else {
+                guard interaction.canSelect(month, day, calendar) else {
                     return
                 }
                 withAnimation {
@@ -67,6 +67,6 @@ struct CustomDayView: CXDayViewRepresentable {
     }
 
     var isSelected: Bool {
-        manager.context.isSelected(day, selectedDate, calendar)
+        interaction.isSelected(day, selectedDate, calendar)
     }
 }

--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithExternalMonthHeaderViewExample.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithExternalMonthHeaderViewExample.swift
@@ -47,7 +47,7 @@ struct WeekdayOnlyHeaderView: CXCalendarHeaderViewRepresentable {
     let month: Date
 
     var body: some View {
-        HStack(spacing: manager.context.columnPadding) {
+        HStack(spacing: layout.columnPadding) {
             let titles = calendar.veryShortWeekdaySymbols
             ForEach(titles.indices, id: \.self) { index in
                 Text(titles[index])

--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithRangePickExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithRangePickExampleView.swift
@@ -140,7 +140,7 @@ struct RangeDay: CXDayViewRepresentable {
             }
             .onTapGesture {
                 withAnimation {
-                    manager.context.onSelected?(day)
+                    interaction.onSelected?(day)
                 }
             }
     }

--- a/Sources/CXCalendar/CXPagedCalendar.swift
+++ b/Sources/CXCalendar/CXPagedCalendar.swift
@@ -9,7 +9,7 @@ import CXUICore
 import CXLazyPage
 import SwiftUI
 
-public struct CXPagedCalendar: View, CXCalendarAccessible {
+public struct CXPagedCalendar: View, CXCalendarAccessible, CXContextAccessible {
 
     // MARK: - Properties
 
@@ -35,17 +35,17 @@ public struct CXPagedCalendar: View, CXCalendarAccessible {
     }
 
     public var body: some View {
-        VStack(spacing: manager.context.rowPadding) {
-            manager.context.calendarHeader(currentDate).erased
+        VStack(spacing: layout.rowPadding) {
+            compose.calendarHeader(currentDate).erased
 
-            CXLazyPage(axis: manager.context.axis, currentPage: $manager.currentPage) { index in
+            CXLazyPage(axis: layout.axis, currentPage: $manager.currentPage) { index in
                 MonthView(month: manager.makeMonthFromStart(offset: index))
                 Spacer()
             }
         }
         .environment(manager)
         .onChange(of: selectedDate) { oldValue, newValue in
-            manager.context.onSelected?(newValue)
+            interaction.onSelected?(newValue)
         }
         .onChange(of: currentDate) { oldValue, newValue in
             withAnimation {
@@ -53,7 +53,7 @@ public struct CXPagedCalendar: View, CXCalendarAccessible {
             }
         }
         .onChange(of: currentDate) { oldValue, newValue in
-            manager.context.onMonthChanged?(newValue)
+            interaction.onMonthChanged?(newValue)
         }
         .onChange(of: backToToday) { oldValue, newValue in
             manager.resetToToday()

--- a/Sources/CXCalendar/CXScrollableCalendar.swift
+++ b/Sources/CXCalendar/CXScrollableCalendar.swift
@@ -8,7 +8,7 @@
 import CXLazyPage
 import SwiftUI
 
-public struct CXScrollableCalendar: View, CXCalendarAccessible {
+public struct CXScrollableCalendar: View, CXCalendarAccessible, CXContextAccessible {
     @State public var manager: CXCalendarManager
 
     @Binding var backToToday: Bool
@@ -26,12 +26,12 @@ public struct CXScrollableCalendar: View, CXCalendarAccessible {
 
     public var body: some View {
         VStack {
-            manager.context.calendarHeader(currentDate).erased
+            compose.calendarHeader(currentDate).erased
             CXLazyList { index in
                 MonthView(month: manager.makeMonthFromStart(offset: index))
             } heightOf: { index in
-                let rowHeight = Int(manager.context.rowHeight)
-                let rowPadding = Int(manager.context.rowPadding)
+                let rowHeight = Int(layout.rowHeight)
+                let rowPadding = Int(layout.rowPadding)
                 let numberOfWeeks = manager.numberOfWeeks(for: index) + 1 // month header
                 return numberOfWeeks * (rowHeight + rowPadding) - rowPadding
             }

--- a/Sources/CXCalendar/DataModel/CXCalendarStyle.swift
+++ b/Sources/CXCalendar/DataModel/CXCalendarStyle.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  CXCalendarStyle.swift
 //  CXCalendar
 //
 //  Created by Cunqi Xiao on 7/16/25.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum CalendarStyle {
+public enum CXCalendarStyle {
     case paged
 
     case scrollable

--- a/Sources/CXCalendar/DataModel/CalendarCompose.swift
+++ b/Sources/CXCalendar/DataModel/CalendarCompose.swift
@@ -1,0 +1,39 @@
+//
+//  CalendarCompose.swift
+//  CXCalendar
+//
+//  Created by Cunqi Xiao on 7/16/25.
+//
+
+import SwiftUI
+
+public protocol CXCalendarComposeProtocol {
+    /// Closure returning a SwiftUI View for the calendar header, given the current month date.
+    var calendarHeader: (Date) -> any CXCalendarHeaderViewRepresentable { get }
+
+    /// Closure returning a SwiftUI View for the month header, given the current month date.
+    /// This is used to display the month title along with the month view.
+    var monthHeader: ((Date) -> any CXCalendarHeaderViewRepresentable)? { get }
+
+    /// Closure returning a SwiftUI View for the week header, given the current month date.
+    /// This is used to display the week title of calendar view.
+    var weekHeader: (Date) -> any CXCalendarHeaderViewRepresentable { get }
+
+    /// Closure returning a SwiftUI View for individual days, given the month and day dates.
+    var dayView: (Date, Date) -> any CXDayViewRepresentable { get }
+
+    /// Optional closure returning a SwiftUI View to overlay when a day is selected.
+    var accessoryView: ((Date) -> any View)? { get }
+}
+
+struct CalendarCompose: CXCalendarComposeProtocol {
+    let calendarHeader: (Date) -> any CXCalendarHeaderViewRepresentable
+
+    let monthHeader: ((Date) -> any CXCalendarHeaderViewRepresentable)?
+
+    let weekHeader: (Date) -> any CXCalendarHeaderViewRepresentable
+
+    let dayView: (Date, Date) -> any CXDayViewRepresentable
+
+    let accessoryView: ((Date) -> any View)?
+}

--- a/Sources/CXCalendar/DataModel/CalendarInteraction.swift
+++ b/Sources/CXCalendar/DataModel/CalendarInteraction.swift
@@ -1,0 +1,38 @@
+//
+//  CalendarInteraction.swift
+//  CXCalendar
+//
+//  Created by Cunqi Xiao on 7/16/25.
+//
+
+import SwiftUI
+
+public protocol CXCalendarInteractionProtocol {
+    /// Closure to tell if given date can be selected
+    var canSelect: (Date, Date, Calendar) -> Bool { get }
+
+    /// Closure to tell if given date is selected
+    var isSelected: (Date, Date?, Calendar) -> Bool { get }
+
+    /// Boolean indicating whether to hide non-current month days in the calendar.
+    var shouldHideNonCurrentMonthDays: Bool { get }
+
+    /// Callback triggered when a date is selected or deselected.
+    var onSelected: ((Date?) -> Void)? { get }
+
+    /// Callback triggered when the month is changed.
+    var onMonthChanged: ((Date) -> Void)? { get }
+}
+
+struct CalendarInteraction: CXCalendarInteractionProtocol {
+
+    let canSelect: (Date, Date, Calendar) -> Bool
+
+    let isSelected: (Date, Date?, Calendar) -> Bool
+
+    let shouldHideNonCurrentMonthDays: Bool
+
+    let onSelected: ((Date?) -> Void)?
+
+    let onMonthChanged: ((Date) -> Void)?
+}

--- a/Sources/CXCalendar/DataModel/CalendarLayout.swift
+++ b/Sources/CXCalendar/DataModel/CalendarLayout.swift
@@ -1,0 +1,32 @@
+//
+//  CalendarLayout.swift
+//  CXCalendar
+//
+//  Created by Cunqi Xiao on 7/16/25.
+//
+
+import SwiftUI
+
+public protocol CXCalendarLayoutProtocol {
+    /// Orientation of the calendar axis (horizontal or vertical).
+    var axis: Axis { get }
+
+    /// Padding between each column of days.
+    var columnPadding: CGFloat { get }
+
+    /// Padding between each row of days.
+    var rowPadding: CGFloat { get }
+
+    /// Height of each row of month view. it is only used for scrollable calendar.
+    var rowHeight: CGFloat { get }
+}
+
+struct CalendarLayout: CXCalendarLayoutProtocol {
+    let axis: Axis
+
+    let columnPadding: CGFloat
+
+    let rowPadding: CGFloat
+
+    let rowHeight: CGFloat
+}

--- a/Sources/CXCalendar/Protocol/CXCalendarHeaderViewRepresentable.swift
+++ b/Sources/CXCalendar/Protocol/CXCalendarHeaderViewRepresentable.swift
@@ -7,5 +7,5 @@
 
 import SwiftUI
 
-public protocol CXCalendarHeaderViewRepresentable: View, CXCalendarAccessible {
+public protocol CXCalendarHeaderViewRepresentable: View, CXCalendarAccessible, CXContextAccessible {
 }

--- a/Sources/CXCalendar/Protocol/CXContextAccessible.swift
+++ b/Sources/CXCalendar/Protocol/CXContextAccessible.swift
@@ -1,0 +1,39 @@
+//
+//  CXContextAccessible.swift
+//  CXCalendar
+//
+//  Created by Cunqi Xiao on 7/16/25.
+//
+
+import Foundation
+
+@MainActor
+public protocol CXContextAccessible {
+    var manager: CXCalendarManager { get }
+
+    var context: CXCalendarContext { get }
+
+    var layout: CXCalendarLayoutProtocol { get }
+
+    var compose: CXCalendarComposeProtocol { get }
+
+    var interaction: CXCalendarInteractionProtocol { get }
+}
+
+public extension CXContextAccessible {
+    var context: CXCalendarContext {
+        manager.context
+    }
+
+    var layout: CXCalendarLayoutProtocol {
+        context.layout
+    }
+
+    var compose: CXCalendarComposeProtocol {
+        context.compose
+    }
+
+    var interaction: CXCalendarInteractionProtocol {
+        context.interaction
+    }
+}

--- a/Sources/CXCalendar/Protocol/CXDayViewRepresentable.swift
+++ b/Sources/CXCalendar/Protocol/CXDayViewRepresentable.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-public protocol CXDayViewRepresentable: View, CXCalendarAccessible {
+public protocol CXDayViewRepresentable: View, CXCalendarAccessible, CXContextAccessible {
 
     var month: Date { get }
 

--- a/Sources/CXCalendar/View/CalendarHeaderView.swift
+++ b/Sources/CXCalendar/View/CalendarHeaderView.swift
@@ -26,7 +26,7 @@ struct CalendarHeaderView: CXCalendarHeaderViewRepresentable {
                 }
             }
             Divider()
-            manager.context.weekHeader(month).erased
+            compose.weekHeader(month).erased
         }
     }
 

--- a/Sources/CXCalendar/View/DayView.swift
+++ b/Sources/CXCalendar/View/DayView.swift
@@ -23,7 +23,7 @@ struct DayView: View, CXDayViewRepresentable {
     }
 
     var body: some View {
-        if manager.context.shouldHideNonCurrentMonthDays && !isInCurrentMonth {
+        if interaction.shouldHideNonCurrentMonthDays && !isInCurrentMonth {
             Color.clear
         } else {
             Text(numericDay)
@@ -33,7 +33,7 @@ struct DayView: View, CXDayViewRepresentable {
                 .ifElse(manager.context.style == .paged) {
                     $0.aspectRatio(1, contentMode: .fit)
                 } else: {
-                    $0.frame(height: manager.context.rowHeight)
+                    $0.frame(height: layout.rowHeight)
                 }
                 .background(
                     RoundedRectangle(cornerRadius: CXSpacing.halfX)
@@ -45,7 +45,7 @@ struct DayView: View, CXDayViewRepresentable {
                         .padding(1)
                 )
                 .onTapGesture {
-                    guard manager.context.canSelect(month, day, calendar) else {
+                    guard interaction.canSelect(month, day, calendar) else {
                         return
                     }
                     withAnimation {
@@ -71,6 +71,6 @@ struct DayView: View, CXDayViewRepresentable {
     }
 
     private var isSelected: Bool {
-        manager.context.isSelected(day, manager.selectedDate, calendar)
+        interaction.isSelected(day, manager.selectedDate, calendar)
     }
 }

--- a/Sources/CXCalendar/View/MonthView.swift
+++ b/Sources/CXCalendar/View/MonthView.swift
@@ -8,7 +8,7 @@
 import CXFoundation
 import SwiftUI
 
-struct MonthView: View, CXCalendarAccessible {
+struct MonthView: View, CXCalendarAccessible, CXContextAccessible {
     @Environment(CXCalendarManager.self) var manager
 
     let month: Date
@@ -23,21 +23,21 @@ struct MonthView: View, CXCalendarAccessible {
     // MARK: - Initializer
 
     var body: some View {
-        VStack(spacing: manager.context.rowPadding) {
-            if let monthHeader = manager.context.monthHeader {
+        VStack(spacing: layout.rowPadding) {
+            if let monthHeader = compose.monthHeader {
                 monthHeader(month)
-                    .frame(height: manager.context.rowHeight)
+                    .frame(height: layout.rowHeight)
                     .frame(maxWidth: .infinity)
                     .erased
             }
 
-            LazyVGrid(columns: manager.columns, spacing: manager.context.rowPadding) {
+            LazyVGrid(columns: manager.columns, spacing: layout.rowPadding) {
                 ForEach(days) { day in
-                    manager.context.dayView(month, day.value).erased
+                    compose.dayView(month, day.value).erased
                 }
             }
 
-            if let accessoryView = manager.context.accessoryView,
+            if let accessoryView = compose.accessoryView,
                let selectedDate = manager.selectedDate {
                 accessoryView(selectedDate).erased
                     .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/Sources/CXCalendar/View/WeekHeaderView.swift
+++ b/Sources/CXCalendar/View/WeekHeaderView.swift
@@ -13,7 +13,7 @@ struct WeekHeaderView: CXCalendarHeaderViewRepresentable {
     let month: Date
 
     var body: some View {
-        LazyVGrid(columns: manager.columns, spacing: manager.context.rowPadding) {
+        LazyVGrid(columns: manager.columns, spacing: layout.rowPadding) {
             let titles = calendar.veryShortWeekdaySymbols
             ForEach(titles.indices, id: \.self) { index in
                 Text(titles[index])

--- a/Sources/CXCalendar/ViewModel/CXCalendarManager.swift
+++ b/Sources/CXCalendar/ViewModel/CXCalendarManager.swift
@@ -33,7 +33,7 @@ public class CXCalendarManager {
 
     init(context: CXCalendarContext) {
         self.context = context
-        self.columns = Array(repeating: GridItem(.flexible(), spacing: context.columnPadding), count: 7)
+        self.columns = Array(repeating: GridItem(.flexible(), spacing: context.layout.columnPadding), count: 7)
 
         self.startDate = context.startDate
         self.selectedDate = context.selectedDate


### PR DESCRIPTION
1. Create `CalendarLayout`, `CalendarCompose`, `CalendarInteraction` to split `CalendarContext` into small pieces
2. Create `CXCalendarContextAccessible` to provide convenient access methods