### PR TITLE
[CXCalendar] Implement dynamic month grid generation method

### DIFF
--- a/Sources/CXCalendar/CXScrollableCalendar.swift
+++ b/Sources/CXCalendar/CXScrollableCalendar.swift
@@ -32,8 +32,8 @@ public struct CXScrollableCalendar: View, CXCalendarAccessible, CXContextAccessi
             } heightOf: { index in
                 let rowHeight = Int(layout.rowHeight)
                 let rowPadding = Int(layout.rowPadding)
-                let numberOfWeeks = manager.numberOfWeeks(for: index) + 1 // month header
-                return numberOfWeeks * (rowHeight + rowPadding) - rowPadding
+                let numberOfRows = manager.numberOfRows(for: index)
+                return numberOfRows * (rowHeight + rowPadding) - rowPadding
             }
         }
         .environment(manager)

--- a/Sources/CXCalendar/Extension/Calendar+DateGenerator.swift
+++ b/Sources/CXCalendar/Extension/Calendar+DateGenerator.swift
@@ -16,7 +16,7 @@ extension Calendar {
     /// Generate month grid dates with leading and trailing dates in fix 42 cells.
     /// - Parameter monthInterval: month interval for current month
     /// - Returns: an array of `IdentifiableDate` representing the month grid with fixed 42 cells.
-    func makeMonthGridDates(from monthInterval: DateInterval) -> [IdentifiableDate] {
+    func makeFixedMonthGridDates(from monthInterval: DateInterval) -> [IdentifiableDate] {
         let firstDay = monthInterval.start
 
         let lead = (component(.weekday, from: firstDay) - firstWeekday + 7) % 7
@@ -28,6 +28,39 @@ extension Calendar {
             }
             return IdentifiableDate(value: day, id: index)
         }
+    }
+    
+    /// Generates a dynamic month grid of dates based on the provided month interval. the size of the grid
+    /// is determined by the number of weeks in the month, which can vary.
+    /// - Parameter monthInterval: The date interval representing the month for which to generate the grid.
+    /// - Returns: An array of `IdentifiableDate` representing the dates in the month grid.
+    func makeDynamicMonthGridDates(from monthInterval: DateInterval) -> [IdentifiableDate] {
+        let firstDay = monthInterval.start
+        let lastDay = self.date(byAdding: .day, value: -1, to: monthInterval.end)!
+
+        guard let startWeekInterval = dateInterval(of: .weekOfMonth, for: firstDay),
+              let endWeekInterval = dateInterval(of: .weekOfMonth, for: lastDay) else {
+            return []
+        }
+
+        let startDate = startWeekInterval.start
+        let endDate = endWeekInterval.end
+
+        var result = [IdentifiableDate]()
+        var current = startDate
+        var index = 0
+
+        while current < endDate {
+            result.append(IdentifiableDate(value: current, id: index))
+
+            guard let next = self.date(byAdding: .day, value: 1, to: current) else {
+                break
+            }
+            index += 1
+            current = next
+        }
+
+        return result
     }
 
     /// Calculates the number of weeks in the month of a given date.

--- a/Sources/CXCalendar/View/MonthView.swift
+++ b/Sources/CXCalendar/View/MonthView.swift
@@ -14,10 +14,7 @@ struct MonthView: View, CXCalendarAccessible, CXContextAccessible {
     let month: Date
 
     private var days: [IdentifiableDate] {
-        guard let monthInterval = calendar.dateInterval(of: .month, for: month) else {
-            return []
-        }
-        return calendar.makeMonthGridDates(from: monthInterval)
+        manager.makeMonthGridDates(for: month)
     }
 
     // MARK: - Initializer

--- a/Sources/CXCalendar/ViewModel/CXCalendarManager.swift
+++ b/Sources/CXCalendar/ViewModel/CXCalendarManager.swift
@@ -5,7 +5,7 @@
 //  Created by Cunqi Xiao on 7/13/25.
 //
 
-import Foundation
+import CXFoundation
 import SwiftUI
 import Observation
 
@@ -73,8 +73,21 @@ public class CXCalendarManager {
         context.calendar.date(byAdding: .month, value: offset, to: startDate)!
     }
 
-    func numberOfWeeks(for index: Int) -> Int {
-        context.calendar.numberOfWeeks(inMonthOf: makeMonthFromStart(offset: index))
+    func makeMonthGridDates(for month: Date) -> [IdentifiableDate] {
+        guard let monthInterval = context.calendar.dateInterval(of: .month, for: month) else {
+            return []
+        }
+
+        switch context.style {
+        case .paged:
+            return context.calendar.makeFixedMonthGridDates(from: monthInterval)
+        case .scrollable:
+            return context.calendar.makeDynamicMonthGridDates(from: monthInterval)
+        }
+    }
+
+    func numberOfRows(for index: Int) -> Int {
+        context.calendar.numberOfWeeks(inMonthOf: makeMonthFromStart(offset: index)) + 1 // +1 for month header
     }
 }
 


### PR DESCRIPTION
1. Rename `numberOfWeeks` to `numberOfRows`
2. Rename `makeMonthGridDates` to `makeFixedMonthGridDates`
3. Create `makeDynamicMonthGridDates` method to generate proper data set for `CXScrollableCalendar`
4. Create `makeMonthGridDates` in `CXCalendarManager`, this will be used to create the data set for `MonthView` based on different calendar style