### PR TITLE
[CXCalendar] Rename MonthView to CalendarBodyView

### DIFF
--- a/Sources/CXCalendar/CXPagedCalendar.swift
+++ b/Sources/CXCalendar/CXPagedCalendar.swift
@@ -40,7 +40,7 @@ public struct CXPagedCalendar: View, CXCalendarAccessible, CXContextAccessible {
             compose.calendarHeader(currentDate).erased
 
             CXLazyPage(axis: layout.axis, currentPage: $manager.currentPage) { index in
-                MonthView(month: manager.makeMonthFromStart(offset: index))
+                CalendarBodyView(month: manager.makeMonthFromStart(offset: index))
                 Spacer()
             }
         }

--- a/Sources/CXCalendar/CXScrollableCalendar.swift
+++ b/Sources/CXCalendar/CXScrollableCalendar.swift
@@ -36,7 +36,7 @@ public struct CXScrollableCalendar: View, CXCalendarAccessible, CXContextAccessi
         VStack {
             compose.calendarHeader(currentDate).erased
             CXLazyList(currentPage: $manager.currentPage) { index in
-                MonthView(month: manager.makeMonthFromStart(offset: index))
+                CalendarBodyView(month: manager.makeMonthFromStart(offset: index))
             } heightOf: { index in
                 let rowHeight = Int(layout.rowHeight)
                 let rowPadding = Int(layout.rowPadding)

--- a/Sources/CXCalendar/DataModel/CXCalendarContext.swift
+++ b/Sources/CXCalendar/DataModel/CXCalendarContext.swift
@@ -56,7 +56,7 @@ extension CXCalendarContext {
 
             // CXCalendarComposeProtocol
             calendarHeader = context.compose.calendarHeader
-            monthHeader = context.compose.monthHeader
+            bodyHeader = context.compose.bodyHeader
             weekHeader = context.compose.weekHeader
             dayView = context.compose.dayView
             accessoryView = context.compose.accessoryView
@@ -102,7 +102,7 @@ extension CXCalendarContext {
                 CalendarHeaderView(month: month)
             }
 
-        public private(set) var monthHeader: ((Date) -> any CXCalendarHeaderViewRepresentable)?
+        public private(set) var bodyHeader: ((Date) -> any CXCalendarHeaderViewRepresentable)?
 
         public private(set) var weekHeader: (Date)
             -> any CXCalendarHeaderViewRepresentable = { month in
@@ -141,7 +141,7 @@ extension CXCalendarContext {
     public static var paged: CXCalendarContext {
         CXCalendarContext.Builder()
             .style(.paged)
-            .monthHeader(nil)
+            .bodyHeader(nil)
             .build()
     }
 
@@ -155,7 +155,7 @@ extension CXCalendarContext {
             .calendarHeader { month in
                 WeekHeaderView(month: month)
             }
-            .monthHeader { month in
+            .bodyHeader { month in
                 MonthHeaderView(month: month)
             }
             .build()
@@ -223,9 +223,9 @@ extension CXCalendarContext.Builder {
         return self
     }
 
-    public func monthHeader(_ monthHeader: ((Date) -> any CXCalendarHeaderViewRepresentable)?)
+    public func bodyHeader(_ bodyHeader: ((Date) -> any CXCalendarHeaderViewRepresentable)?)
         -> CXCalendarContext.Builder {
-        self.monthHeader = monthHeader
+        self.bodyHeader = bodyHeader
         return self
     }
 
@@ -285,7 +285,7 @@ extension CXCalendarContext.Builder {
         )
         let compose = CalendarCompose(
             calendarHeader: calendarHeader,
-            monthHeader: monthHeader,
+            bodyHeader: bodyHeader,
             weekHeader: weekHeader,
             dayView: dayView,
             accessoryView: accessoryView

--- a/Sources/CXCalendar/DataModel/CalendarCompose.swift
+++ b/Sources/CXCalendar/DataModel/CalendarCompose.swift
@@ -13,9 +13,9 @@ public protocol CXCalendarComposeProtocol {
     /// Closure returning a SwiftUI View for the calendar header, given the current month date.
     var calendarHeader: (Date) -> any CXCalendarHeaderViewRepresentable { get }
 
-    /// Closure returning a SwiftUI View for the month header, given the current month date.
+    /// Closure returning a SwiftUI View for the body header, given the current month date.
     /// This is used to display the month title along with the month view.
-    var monthHeader: ((Date) -> any CXCalendarHeaderViewRepresentable)? { get }
+    var bodyHeader: ((Date) -> any CXCalendarHeaderViewRepresentable)? { get }
 
     /// Closure returning a SwiftUI View for the week header, given the current month date.
     /// This is used to display the week title of calendar view.
@@ -33,7 +33,7 @@ public protocol CXCalendarComposeProtocol {
 struct CalendarCompose: CXCalendarComposeProtocol {
     let calendarHeader: (Date) -> any CXCalendarHeaderViewRepresentable
 
-    let monthHeader: ((Date) -> any CXCalendarHeaderViewRepresentable)?
+    let bodyHeader: ((Date) -> any CXCalendarHeaderViewRepresentable)?
 
     let weekHeader: (Date) -> any CXCalendarHeaderViewRepresentable
 

--- a/Sources/CXCalendar/View/CalendarBodyView.swift
+++ b/Sources/CXCalendar/View/CalendarBodyView.swift
@@ -1,5 +1,5 @@
 //
-//  MonthView.swift
+//  CalendarBodyView.swift
 //  CXCalendar
 //
 //  Created by Cunqi Xiao on 7/13/25.
@@ -8,7 +8,7 @@
 import CXFoundation
 import SwiftUI
 
-struct MonthView: View, CXCalendarAccessible, CXContextAccessible {
+struct CalendarBodyView: View, CXCalendarAccessible, CXContextAccessible {
     // MARK: Internal
 
     @Environment(CXCalendarManager.self) var manager
@@ -19,7 +19,7 @@ struct MonthView: View, CXCalendarAccessible, CXContextAccessible {
 
     var body: some View {
         VStack(spacing: layout.rowPadding) {
-            if let monthHeader = compose.monthHeader {
+            if let monthHeader = compose.bodyHeader {
                 monthHeader(month)
                     .frame(height: layout.rowHeight)
                     .frame(maxWidth: .infinity)


### PR DESCRIPTION
Rename `MonthView` to `CalendarBodyView`, this is the pre-refactor before implementing week view, calendar body will be a more meaningful name since the data inside might changed