### PR TITLE
[CXCalendar] optimize weekly accessory view

### DIFF
--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomDayExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomDayExampleView.swift
@@ -36,7 +36,7 @@ struct CustomDayView: CXCalendarDayViewRepresentable {
     let day: Date
 
     var isInRange: Bool {
-        dateInterval.containsExceptEnd(day, calendar: calendar)
+        dateInterval.containsExceptEnd(day, calendar)
     }
 
     var isStartDate: Bool {

--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomSelectLogicExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/CalendarWithCustomSelectLogicExampleView.swift
@@ -10,7 +10,7 @@ import CXFoundation
 import SwiftUI
 
 struct CalendarWithCustomSelectLogicExampleView: View {
-    @State private var selectedDate: Date? = nil
+    // MARK: Internal
 
     var body: some View {
         let context = CXCalendarContext.month(.page)
@@ -30,4 +30,8 @@ struct CalendarWithCustomSelectLogicExampleView: View {
             .navigationTitle("Custom Select Logic Calendar")
             .navigationBarTitleDisplayMode(.inline)
     }
+
+    // MARK: Private
+
+    @State private var selectedDate: Date? = nil
 }

--- a/Sources/CXCalendar/CXCalendarView.swift
+++ b/Sources/CXCalendar/CXCalendarView.swift
@@ -15,7 +15,7 @@ public struct CXCalendarView: CXCalendarViewRepresentable {
 
     /// Initializes a `CXCalendar` instance with the specified context and optional
     /// binding to control returning to the start date.
-    /// 
+    ///
     /// - Parameters:
     ///   - context: The context for the calendar, which includes configuration options like axis and header view.
     ///   - backToStart: A binding that indicates whether the calendar should return to the start date when it changes.

--- a/Sources/CXCalendar/Extension/DateInterval+Compare.swift
+++ b/Sources/CXCalendar/Extension/DateInterval+Compare.swift
@@ -8,13 +8,12 @@
 import Foundation
 
 extension DateInterval {
-
     /// Checks if the date interval contains a specific date. excluding the end date.
     /// - Parameters:
     ///   - date: The date to check if it falls within the interval.
     ///   - calendar: The calendar used for date calculations.
     /// - Returns: `true` if the date is within the interval, `false` otherwise.
-    public func containsExceptEnd(_ date: Date, calendar: Calendar) -> Bool {
+    public func containsExceptEnd(_ date: Date, _ calendar: Calendar) -> Bool {
         let startDay = calendar.startOfDay(for: start)
         let lastDay = calendar.startOfDay(for: end)
         let dateDay = calendar.startOfDay(for: date)

--- a/Sources/CXCalendar/Protocol/CXCalendarAccessible.swift
+++ b/Sources/CXCalendar/Protocol/CXCalendarAccessible.swift
@@ -14,17 +14,17 @@ import Foundation
 public protocol CXCalendarAccessible {
     /// The calendar manager that handles the calendar view's data and behavior.
     var manager: CXCalendarManager { get }
-    
+
     /// The calendar used for date calculations and formatting.
     var calendar: Calendar { get }
-    
+
     /// The start date of the calendar, representing the first date displayed in the calendar view.
     var startDate: Date { get }
-    
+
     /// The current anchor date of the calendar, which is typically the date offset from the start date
     /// based on the `currentPage`
     var currentAnchorDate: Date { get }
-    
+
     /// The current date interval of the calendar, representing the range of dates currently displayed.
     var currentDateInterval: DateInterval { get }
 
@@ -43,7 +43,7 @@ extension CXCalendarAccessible {
     }
 
     public var currentAnchorDate: Date {
-        manager.currentDate
+        manager.currentAnchorDate
     }
 
     public var currentDateInterval: DateInterval {

--- a/Sources/CXCalendar/Protocol/CXCalendarDayViewRepresentable.swift
+++ b/Sources/CXCalendar/Protocol/CXCalendarDayViewRepresentable.swift
@@ -11,14 +11,14 @@ import SwiftUI
 public protocol CXCalendarDayViewRepresentable: CXCalendarViewRepresentable {
     /// The date interval that currently being displayed
     var dateInterval: DateInterval { get }
-    
+
     /// The date that represents the day being displayed in the view.
     var day: Date { get }
-    
+
     /// Tell whether the `day` is in some sort of range, such as the current month or week.
     /// this can be calculated by leveraging the `dateInterval` property.
     var isInRange: Bool { get }
-    
+
     /// /// A Boolean value indicating whether the day is startDate.
     var isStartDate: Bool { get }
 }

--- a/Sources/CXCalendar/Protocol/CXContextAccessible.swift
+++ b/Sources/CXCalendar/Protocol/CXContextAccessible.swift
@@ -14,13 +14,13 @@ import Foundation
 public protocol CXContextAccessible {
     /// The calendar manager that handles the calendar view's data and behavior.
     var manager: CXCalendarManager { get }
-    
+
     /// The calendar context that contains the configuration and state of the calendar.
     var context: CXCalendarContext { get }
-    
+
     /// The type of calendar being used (month or week).
     var calendarType: CXCalendarType { get }
-    
+
     /// The layout configuration for the calendar, defining how the calendar's items are arranged.
     var layout: CXCalendarLayoutProtocol { get }
 

--- a/Sources/CXCalendar/View/Accessory/CXCalendarWeeklyAccessoryWrapperView.swift
+++ b/Sources/CXCalendar/View/Accessory/CXCalendarWeeklyAccessoryWrapperView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 public struct CXCalendarWeeklyAccessoryWrapperView<AccessoryContent: View>:
     CXCalendarViewRepresentable {
     // MARK: Lifecycle
-    
+
     /// Creates a new instance of `CXCalendarWeeklyAccessoryWrapperView`.
     /// - Parameters:
     ///   - date: The date that the accessory date relates to.
@@ -46,7 +46,20 @@ public struct CXCalendarWeeklyAccessoryWrapperView<AccessoryContent: View>:
         }
         .onChange(of: manager.selectedDate) { _, newValue in
             if !calendar.isSameDay(newValue, focusedDate) {
-                withAnimation {
+                // If the weekly accessory view is not currently forcused on the selected date,
+                // this means the user is scrolling the calendar view.
+                // In all of following conditions were met, we should disable the animation.
+                // 1. The focused date is not in the current week interval.
+                // 2. user is scrolling backward and selected date is smaller than the focused date.
+
+                let isInRange = manager.currentDateInterval.containsExceptEnd(focusedDate, calendar)
+                let isMovingBackward = calendar.compare(
+                    newValue,
+                    to: focusedDate,
+                    toGranularity: .day
+                ) == .orderedAscending
+                let shouldDisableAnimation = !isInRange && isMovingBackward
+                withAnimation(shouldDisableAnimation ? nil : .default) {
                     focusedDate = newValue
                 }
             }

--- a/Sources/CXCalendar/View/Body/CalendarBodyContentView.swift
+++ b/Sources/CXCalendar/View/Body/CalendarBodyContentView.swift
@@ -24,15 +24,17 @@ struct CalendarBodyContentView: CXCalendarBodyContentViewRepresentable {
             }
         }
         .onChange(of: manager.currentPage) { oldValue, newValue in
-            // For weekly calendar, if selected date is not in current week interval,
-            // select start or last day as the initial selected date.
-            // if selected date equals to start date. means it is a reset, do nothing.
-            if case .week = calendarType,
-               !dateInterval.containsExceptEnd(selectedDate, calendar: calendar),
-               !calendar.isSameDay(selectedDate, startDate) {
+            let containsSelectedDate = dateInterval.containsExceptEnd(selectedDate, calendar)
+            let isTodaySelected = calendar.isSameDay(selectedDate, startDate)
+            if case .week = calendarType, !containsSelectedDate, !isTodaySelected {
+                // For weekly calendar, if selected date is not in current week interval,
+                // select start or last day as the initial selected date.
+                // if selected date equals to start date. means it is a reset, do nothing.
                 manager.selectedDate = newValue > oldValue
                     ? dateInterval.start
                     : dateInterval.lastDay(calendar: calendar)
+            } else if case .month = calendarType {
+                manager.shouldPresentAccessoryView = false
             }
         }
     }

--- a/Sources/CXCalendar/View/Body/CalendarBodyView.swift
+++ b/Sources/CXCalendar/View/Body/CalendarBodyView.swift
@@ -27,9 +27,10 @@ struct CalendarBodyView: CXCalendarViewRepresentable {
                     .erased
             }
 
-            compose.bodyContent(date).erased
+            CalendarBodyContentView(date: date)
 
-            if let accessoryView = compose.accessoryView {
+            if let accessoryView = compose.accessoryView,
+               manager.shouldPresentAccessoryView(for: date) {
                 accessoryView(selectedDate)
                     .erased
                     .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/Sources/CXCalendar/View/Body/CalendarDayView.swift
+++ b/Sources/CXCalendar/View/Body/CalendarDayView.swift
@@ -20,7 +20,7 @@ struct CalendarDayView: CXCalendarDayViewRepresentable {
     let namespace: Namespace.ID
 
     var isInRange: Bool {
-        dateInterval.containsExceptEnd(day, calendar: calendar)
+        dateInterval.containsExceptEnd(day, calendar)
     }
 
     var isStartDate: Bool {
@@ -68,7 +68,12 @@ struct CalendarDayView: CXCalendarDayViewRepresentable {
                     guard interaction.canSelect(dateInterval, day, calendar) else {
                         return
                     }
-                    withAnimation(.interpolatingSpring) {
+                    withAnimation {
+                        if calendar.isSameDay(day, selectedDate) {
+                            manager.togglePresentAccessoryView()
+                        } else {
+                            manager.shouldPresentAccessoryView = true
+                        }
                         manager.selectedDate = day
                     }
                 }


### PR DESCRIPTION
1.  Remove unnecessary method label `calendar` from `containsExceptEnd`
2. Rename `currentDate` in `CXCalendarManager` to `currentAnchorDate`
3. Add comment to explain the `focusedDate` updating logic in `CXCalendarWeeklyAccessoryWrapperView`
4. Add comments and update logic when `currentPage` changed
5. Optimize accessory view presentation logic and animations
6. style reformatting