### PR TITLE
[CXCalendar] Prepare for yearly view implementation

### DIFF
--- a/Examples/CXCalendarExamples/CXCalendarExamples/Examples/AppleStyleCalendar/AppleStyleCalendarExampleView.swift
+++ b/Examples/CXCalendarExamples/CXCalendarExamples/Examples/AppleStyleCalendar/AppleStyleCalendarExampleView.swift
@@ -1,0 +1,20 @@
+//
+//  AppleStyleCalendarExampleView.swift
+//  CXCalendarExamples
+//
+//  Created by Cunqi Xiao on 7/25/25.
+//
+
+import CXCalendar
+import SwiftUI
+
+struct AppleStyleCalendarExampleView: View {
+    let context = CXCalendarContext.month(.scroll)
+        .builder
+        .build()
+
+    var body: some View {
+        CXCalendarView(context: context)
+            .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Sources/CXCalendar/DataModel/CXCalendarContext.swift
+++ b/Sources/CXCalendar/DataModel/CXCalendarContext.swift
@@ -60,6 +60,7 @@ extension CXCalendarContext {
 
             // CXCalendarComposeProtocol
             calendarHeader = context.compose.calendarHeader
+            body = context.compose.body
             bodyHeader = context.compose.bodyHeader
             bodyContent = context.compose.bodyContent
             weekHeader = context.compose.weekHeader
@@ -101,6 +102,10 @@ extension CXCalendarContext {
 
         public private(set) var calendarHeader: CalendarHeaderMaker = { month in
             CalendarHeaderView(date: month)
+        }
+
+        public private(set) var body: BodyMaker = { month in
+            CalendarMonthlyBodyView(date: month)
         }
 
         public private(set) var bodyHeader: BodyHeaderMaker?
@@ -194,6 +199,11 @@ extension CXCalendarContext.Builder {
         return self
     }
 
+    public func body(_ body: @escaping BodyMaker) -> CXCalendarContext.Builder {
+        self.body = body
+        return self
+    }
+
     public func bodyHeader(_ bodyHeader: BodyHeaderMaker?) -> CXCalendarContext.Builder {
         self.bodyHeader = bodyHeader
         return self
@@ -260,6 +270,7 @@ extension CXCalendarContext.Builder {
         )
         let compose = CalendarCompose(
             calendarHeader: calendarHeader,
+            body: body,
             bodyHeader: bodyHeader,
             bodyContent: bodyContent,
             weekHeader: weekHeader,

--- a/Sources/CXCalendar/DataModel/CalendarCompose.swift
+++ b/Sources/CXCalendar/DataModel/CalendarCompose.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
 public typealias CalendarHeaderMaker = (Date) -> any CXCalendarViewRepresentable
 
+public typealias BodyMaker = (Date) -> any CXCalendarViewRepresentable
+
 public typealias BodyHeaderMaker = (Date) -> any CXCalendarViewRepresentable
 
 public typealias BodyContentMaker = (Date) -> any CXCalendarBodyContentViewRepresentable
@@ -27,6 +29,10 @@ public typealias AccessoryViewMaker = (Date) -> any View
 public protocol CXCalendarComposeProtocol {
     /// Closure returning a SwiftUI View for the calendar header, given the current month date.
     var calendarHeader: CalendarHeaderMaker { get }
+
+    /// Closure returning a SwiftUI View for the body, given the current month date.
+    /// This is used to display the main content of the calendar view.
+    var body: BodyMaker { get }
 
     /// Closure returning a SwiftUI View for the body header, given the current month date.
     /// This is used to display the month title along with the month view.
@@ -51,6 +57,8 @@ public protocol CXCalendarComposeProtocol {
 
 struct CalendarCompose: CXCalendarComposeProtocol {
     let calendarHeader: CalendarHeaderMaker
+
+    let body: BodyMaker
 
     let bodyHeader: BodyHeaderMaker?
 

--- a/Sources/CXCalendar/Protocol/CXCalendarBodyViewRepresentable.swift
+++ b/Sources/CXCalendar/Protocol/CXCalendarBodyViewRepresentable.swift
@@ -1,0 +1,13 @@
+//
+//  CXCalendarBodyViewRepresentable.swift
+//  CXCalendar
+//
+//  Created by Cunqi Xiao on 7/25/25.
+//
+
+import SwiftUI
+
+/// `CXCalendarBodyViewRepresentable` is a protocol that defines the requirements for a calendar body view.
+public protocol CXCalendarBodyViewRepresentable: CXCalendarViewRepresentable {
+    var date: Date { get }
+}

--- a/Sources/CXCalendar/View/Body/CalendarMonthlyBodyView.swift
+++ b/Sources/CXCalendar/View/Body/CalendarMonthlyBodyView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 /// This view represents the monthly body of the calendar,
 /// displaying the header, body content, and any accessory views.
-struct CalendarMonthlyBodyView: CXCalendarViewRepresentable {
+struct CalendarMonthlyBodyView: CXCalendarBodyViewRepresentable {
     @Environment(CXCalendarManager.self) var manager
 
     let date: Date

--- a/Sources/CXCalendar/View/Body/CalendarMonthlyBodyView.swift
+++ b/Sources/CXCalendar/View/Body/CalendarMonthlyBodyView.swift
@@ -10,8 +10,9 @@ import SwiftUI
 
 // MARK: - CalendarBodyView
 
-/// This view represents the body of the calendar, displaying the header, body content, and any accessory views.
-struct CalendarBodyView: CXCalendarViewRepresentable {
+/// This view represents the monthly body of the calendar,
+/// displaying the header, body content, and any accessory views.
+struct CalendarMonthlyBodyView: CXCalendarViewRepresentable {
     @Environment(CXCalendarManager.self) var manager
 
     let date: Date

--- a/Sources/CXCalendar/View/PagedCalendarView.swift
+++ b/Sources/CXCalendar/View/PagedCalendarView.swift
@@ -32,7 +32,7 @@ struct PagedCalendarView: CXCalendarViewRepresentable {
                 .padding(.horizontal, layout.calendarHPadding)
 
             CXLazyPage(axis: layout.axis, currentPage: $manager.currentPage) { index in
-                CalendarBodyView(date: manager.makeDate(for: index))
+                CalendarMonthlyBodyView(date: manager.makeDate(for: index))
                     .padding(.horizontal, layout.calendarHPadding)
             }
         }

--- a/Sources/CXCalendar/View/ScrollableCalendarView.swift
+++ b/Sources/CXCalendar/View/ScrollableCalendarView.swift
@@ -28,7 +28,7 @@ struct ScrollableCalendarView: CXCalendarViewRepresentable {
                 .erased
                 .padding(.horizontal, layout.calendarHPadding)
             CXLazyList(currentPage: $manager.currentPage) { index in
-                CalendarBodyView(date: manager.makeDate(for: index))
+                CalendarMonthlyBodyView(date: manager.makeDate(for: index))
                     .padding(.horizontal, layout.calendarHPadding)
             } heightOf: { index in
                 let rowHeight = Int(layout.rowHeight)


### PR DESCRIPTION
1. Rename `CalendarBodyView` to `CalendarMonthlyBodyView` to distinguish calendar yearly body 
2. allow dynamic change calendar body